### PR TITLE
Warn about missing placeholder or dimensions

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,1 +1,9 @@
 export const ELEMENT_NAME = 'progressive-image';
+export const MESSAGES = {
+  placeholderElement: {
+    missing: '<progressive-image> requires a <img> or <svg> element as its only child. See https://andreruffert.github.io/progressive-image-element/examples'
+  },
+  dimensions: {
+    missing: 'An <img> element was loaded, but had no dimensions specified. Specifying dimensions is necessary. See https://github.com/andreruffert/progressive-image-element/pull/4'
+  }
+};

--- a/constants.js
+++ b/constants.js
@@ -1,7 +1,7 @@
 export const ELEMENT_NAME = 'progressive-image';
 export const MESSAGES = {
   placeholderElement: {
-    missing: '<progressive-image> requires a <img> or <svg> element as its only child. See https://andreruffert.github.io/progressive-image-element/examples'
+    missing: '<progressive-image> requires a <img> or <svg> element as its child. See https://andreruffert.github.io/progressive-image-element/examples'
   },
   dimensions: {
     missing: 'An <img> element was loaded, but had no dimensions specified. Specifying dimensions is necessary. See https://github.com/andreruffert/progressive-image-element/pull/4'

--- a/progressive-image-element.js
+++ b/progressive-image-element.js
@@ -8,7 +8,7 @@ class ProgressiveImageElement extends HTMLElement {
     const width = placeholderElement?.getAttribute('width');
     const height = placeholderElement?.getAttribute('height');
     if (!placeholderElement) console.warn(MESSAGES.placeholderElement.missing);
-    if (!width && !height) console.warn(MESSAGES.dimensions.missing);
+    if (placeholderElement && (!width && !height)) console.warn(MESSAGES.dimensions.missing);
     this._placeholderImage = placeholderElement?.tagName === 'IMG' ? placeholderElement : null;
     this._image = this._placeholderImage?.cloneNode(true) || new Image();
     if (LAZY_LOADING_SUPPORT) return;

--- a/progressive-image-element.js
+++ b/progressive-image-element.js
@@ -1,9 +1,15 @@
+import { MESSAGES } from './constants';
 const LAZY_LOADING_SUPPORT = 'loading' in HTMLImageElement.prototype;
 
 class ProgressiveImageElement extends HTMLElement {
   constructor() {
     super();
-    this._placeholderImage = this.querySelector('img');
+    const placeholderElement = this.querySelector('img, svg');
+    const width = placeholderElement?.getAttribute('width');
+    const height = placeholderElement?.getAttribute('height');
+    if (!placeholderElement) console.warn(MESSAGES.placeholderElement.missing);
+    if (!width && !height) console.warn(MESSAGES.dimensions.missing);
+    this._placeholderImage = placeholderElement?.tagName === 'IMG' ? placeholderElement : null;
     this._image = this._placeholderImage?.cloneNode(true) || new Image();
     if (LAZY_LOADING_SUPPORT) return;
 


### PR DESCRIPTION
Add a console info or something if no img dimensions (`width`, `height`) are specified.

If you currently don't specify the image dimensions the element does not work like you would expect since the actual image has a absolute position. If you don't specify the image dimensions we obviously also have a content reflow which we want to avoid if possible.

The progressive-image only spans the dimensions of the placeholder image if no dimensions are defined e.g. 30x20

```html
<progressive-image
  src="example-image-1x.jpg"
  srcset="example-image-2x.jpg 2x, example-image-1x.jpg 1x"
>
  <!-- Make sure to specify image dimensions -->
  <img src="placeholder-image.jpg" alt="Image" />
</progressive-image>
```

_Preview_
<img width="65" alt="Screenshot 2020-02-04 at 14 27 40" src="https://user-images.githubusercontent.com/464300/73748904-a17a5880-475a-11ea-8fcd-4da3cb80a2ed.png">
