### PR TITLE
feat: introduce ES module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ npm install progressive-image-element
   <link rel="stylesheet" href="https://unpkg.com/progressive-image-element@latest/dist/progressive-image-element.css" />
 
   <!-- Include the custom element script, this could be direct from the package or CDN -->
-  <script src="https://unpkg.com/progressive-image-element@latest/dist/index.js"></script>
+  <script type="module" src="https://unpkg.com/progressive-image-element@latest/dist/progressive-image-element.js"></script>
   ```
 
   or

--- a/docs/index.html
+++ b/docs/index.html
@@ -239,9 +239,8 @@ progressive-image > img.loaded { opacity: 1; }</syntax-highlight>
     </symbol>
   </svg>
 
-  <script src="https://unpkg.com/progressive-image-element@latest/dist/index.js"></script>
-
   <script type="module">
+    import 'https://unpkg.com/progressive-image-element@latest/dist/progressive-image-element.js';
     import 'https://cdn.jsdelivr.net/npm/syntax-highlight-element@1.0.0/+esm';
   </script>
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,16 @@
     "name": "André Ruffert",
     "url": "https://andreruffert.com"
   },
-  "source": "index.js",
-  "main": "dist/progressive-image-element.umd.js",
+  "type": "module",
+  "module": "dist/progressive-image-element.js",
+  "main": "dist/progressive-image-element.umd.cjs",
+  "exports": {
+    ".": {
+      "import": "./dist/progressive-image-element.js",
+      "require": "./dist/progressive-image-element.umd.cjs"
+    },
+    "./style.css": "./dist/progressive-image-element.css"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## What changed (additional context)

Introduce ES module support.

CommonJS is still supported via `dist/progressive-image-element.umd.cjs`